### PR TITLE
Modify auth.php IP eval

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -55,7 +55,7 @@ class auth_plugin_ip extends auth_plugin_manual {
         global $DB, $CFG;
         if (($user = $DB->get_record('user', array('username'=>$username, 'mnethostid'=>$CFG->mnet_localhost_id)))) {
             // Check if IP is one of the restricted ones.
-            $userIp = filter_input(INPUT_SERVER, 'REMOTE_ADDR');
+            $userIp = getremoteaddr();
 
             if (isset($userIp) && $this->is_ip_valid($userIp)) {
                 return validate_internal_user_password($user, $password);


### PR DESCRIPTION
Currently the plugin only gets the users IP form REMOTE_ADDR wich is not an entirely reliable source. a much better source would be the getremoteaddr() function since this is the one moodle uses in the reports. This also prevents issues wen moodle is implemented behind a load balancer. I tested the change in my server and it works like  a charm